### PR TITLE
Proxy added

### DIFF
--- a/docker-compose/common.yml
+++ b/docker-compose/common.yml
@@ -197,6 +197,7 @@ services:
      - orion
     networks:
       - default
+    restart: always
 
 
 volumes:


### PR DESCRIPTION
Now there is a simple proxy that allow the context broker to be accessed by the React webapp (in development)